### PR TITLE
Fix type for parameters accessing

### DIFF
--- a/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
+++ b/src/app/Processor/ProcessorDetail/ProcessorDetail.test.tsx
@@ -39,10 +39,15 @@ describe("ProcessorDetail component", () => {
     expect(comp.queryByText("Action")).toBeInTheDocument();
     expect(comp.queryByText("Send to Slack")).toBeInTheDocument();
     expect(
-      comp.queryByText(sinkProcessor.action.parameters.channel as string)
+      comp.queryByText(
+        (sinkProcessor.action.parameters as { [key: string]: string }).channel
+      )
     ).toBeInTheDocument();
     expect(
-      comp.queryByText(sinkProcessor.action.parameters.webhookUrl as string)
+      comp.queryByText(
+        (sinkProcessor.action.parameters as { [key: string]: string })
+          .webhookUrl
+      )
     ).toBeInTheDocument();
 
     expect(comp.queryByText("Source")).not.toBeInTheDocument();
@@ -74,7 +79,8 @@ describe("ProcessorDetail component", () => {
     expect(comp.queryByText("Demo source")).toBeInTheDocument();
     expect(
       comp.queryByText(
-        sourceProcessor.source.parameters.demoParameter as string
+        (sourceProcessor.source.parameters as { [key: string]: string })
+          .demoParameter
       )
     ).toBeInTheDocument();
 


### PR DESCRIPTION
In the generated model, the `parameters` is a simple `object` (https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox-ui/blob/402ef09b765f7a184ea846183abadb52bbc505cd/openapi/generated/model/action.ts#L34), which is not so useful in our case.

IMHO, `parameters` should be something like a key-value type: https://bobbyhadz.com/blog/typescript-key-value-pair
So my proposed solution is to cast to `{ [key: string]: string }` before accessing to properties